### PR TITLE
use guard-shell to keep an eye on the ragel file

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -1,3 +1,7 @@
+guard 'shell', :all_on_start => true do
+  watch("lib/ruby_ami/lexer.rl.rb") { `rake ragel` }
+end
+
 guard 'rspec', :version => 2, :cli => '--format documentation' do
   watch(%r{^spec/.+_spec\.rb$})
   watch(%r{^lib/(.+)\.rb$})     { |m| "spec/#{m[1]}_spec.rb" }

--- a/ruby_ami.gemspec
+++ b/ruby_ami.gemspec
@@ -33,5 +33,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency %q<simplecov>, [">= 0"]
   s.add_development_dependency %q<simplecov-rcov>, [">= 0"]
   s.add_development_dependency %q<guard-rspec>
+  s.add_development_dependency %q<guard-shell>
   s.add_development_dependency %q<ruby_gntp>
 end


### PR DESCRIPTION
I'm a big fan of guard, and running guard would throw errors if one didn't run ragel first. This monitor the file and generates lexer.rb on first run too.
There's actually a gem called guard-ragel that I tried first, but it hasn't been updated in over a year, and there was no support for running on start, kind of losing the whole purpose of the pull request, so I went with guard-shell and the rake task.
Let me know what you think.
