### PR TITLE
Adding support for AMI Logoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # [develop](https://github.com/adhearsion/ruby_ami)
   * Feature: Allow optional error handler when calling `send_action`
+  * Bugfix: Add support for Goodbye responses instead of processing them as syntax errors 
   * Bugfix: Allow simple example of event handling (switching on `event.name` only) to work by giving connection status events a name to match their class names
 
 # [2.2.1](https://github.com/adhearsion/ruby_ami/compare/v2.2.0...v2.2.1) - [2014-05-22](https://rubygems.org/gems/ruby_ami/versions/2.2.1)

--- a/lib/ruby_ami/lexer.rb
+++ b/lib/ruby_ami/lexer.rb
@@ -11,10 +11,11 @@ module RubyAMI
     EVENT             = /event: *(?<event_name>.*)?/i
     ERROR             = /response: *error/i
     FOLLOWS           = /response: *follows/i
+    GOODBYE           = /response: *goodbye/i
     SCANNER           = /.*?#{STANZA_BREAK}/m
     HEADER_SLICE      = /.*\r\n/
     IMMEDIATE_RESP    = /.*/
-    CLASSIFIER        = /((?<event>#{EVENT})|(?<success>#{SUCCESS})|(?<pong>#{PONG})|(?<follows>#{FOLLOWS})|(?<error>#{ERROR})|(?<immediate>#{IMMEDIATE_RESP})\r\n)\r\n/i
+    CLASSIFIER        = /((?<event>#{EVENT})|(?<success>#{SUCCESS})|(?<pong>#{PONG})|(?<follows>#{FOLLOWS})|(?<error>#{ERROR})|(?<goodbye>#{GOODBYE})|(?<immediate>#{IMMEDIATE_RESP})\r\n)\r\n/i
 
     attr_accessor :ami_version
 
@@ -69,7 +70,7 @@ module RubyAMI
 
       msg = if match[:event]
         Event.new match[:event_name]
-      elsif match[:success] || match[:pong]
+      elsif match[:success] || match[:pong] || match[:goodbye]
         Response.new
       elsif match[:follows]
         response_follows = true

--- a/spec/ruby_ami/stream_spec.rb
+++ b/spec/ruby_ami/stream_spec.rb
@@ -190,6 +190,20 @@ Message: Recording started
         response.should == Response.new('ActionID' => RubyAMI.new_uuid, 'Message' => 'Recording started')
       end
 
+      it 'should handle disconnect as a Response' do
+        response = nil
+        mocked_server(1, lambda { response = @stream.send_action 'Logoff' }) do |val, server|
+          server.send_data <<-EVENT
+Response: Goodbye
+ActionID: #{RubyAMI.new_uuid}
+Message: Thanks for all the fish.
+
+          EVENT
+        end
+  
+        response.should == Response.new('ActionID' => RubyAMI.new_uuid, 'Message' => 'Thanks for all the fish.')
+      end
+
       describe 'when it is an error' do
         describe 'when there is no error handler' do
           it 'should be raised by #send_action, but not kill the stream' do


### PR DESCRIPTION
Sending an AMI Logoff action currently results in a syntax error. This PR updates the lexer to correctly handle the Goodbye response generated by a Logoff, therefore allowing graceful triggered exit.
