### PR TITLE
[BUGFIX] If host is unreachable log an error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # [develop](https://github.com/adhearsion/ruby_ami)
+  * Bugfix: Catch for Errno::HOSTUNREACH error when connecting to AMI
   * Feature: Allow optional error handler when calling `send_action`
   * Bugfix: Add support for Goodbye responses instead of processing them as syntax errors 
   * Bugfix: Allow simple example of event handling (switching on `event.name` only) to work by giving connection status events a name to match their class names

--- a/lib/ruby_ami/stream.rb
+++ b/lib/ruby_ami/stream.rb
@@ -41,7 +41,7 @@ module RubyAMI
       end
       post_init
       loop { receive_data @socket.readpartial(4096) }
-    rescue Errno::ECONNREFUSED, SocketError => e
+    rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH, SocketError => e
       logger.error "Connection failed due to #{e.class}. Check your config and the server."
     rescue EOFError
       logger.info "Client socket closed!"


### PR DESCRIPTION
Added a catch for Errno::HOSTUNREACH which occurs if the specified host IP does not exist.